### PR TITLE
Doc updates for Configure Redis using a ConfigMap

### DIFF
--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -9,21 +9,17 @@ weight: 30
 
 <!-- overview -->
 
-In this tutorial, we will walk through a real world example of how to configure Redis using a ConfigMap.
-
-See [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) for more information about ConfigMaps. 
+In this tutorial, we will walk through a real world example of how to configure Redis using a ConfigMap. See [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) for more information about ConfigMaps. 
 ---
 ## {{% heading "What you'll learn" %}}
 
 In this tutorial, you’ll learn how to do the following tasks:
 
-* Create a ConfigMap with Redis configuration values
-* Create a Redis Pod that mounts and uses the created ConfigMap
-* Verify that the configuration was correctly applied.
-
-
-
-## {{% heading "prerequisites" %}}
+* Create a ConfigMap with Redis configuration values.
+* Create a Redis Pod that mounts and uses the created ConfigMap.
+* Verify that the configuration is correctly applied.
+---
+## {{% heading "Requirements" %}}
 
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -2,7 +2,7 @@
 reviewers:
 - eparis
 - pmorie
-title: Configure Redis using a ConfigMap
+title: Configure Redis with a ConfigMap
 content_type: tutorial
 weight: 30
 ---
@@ -11,7 +11,7 @@ weight: 30
 
 In this tutorial, we will walk through a real world example of how to configure Redis using a ConfigMap. See [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) for more information about ConfigMaps. 
 ---
-## {{% heading "What you'll learn" %}}
+## What you'll learn
 
 In this tutorial, you’ll learn how to do the following tasks:
 
@@ -20,24 +20,17 @@ In this tutorial, you’ll learn how to do the following tasks:
 * Verify that the configuration is correctly applied.
 ---
 ## {{% heading "Requirements" %}}
+{{< include "task-tutorial-prereqs.md" >}}
 
-
-{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
-
-* The example shown on this page works with `kubectl` 1.14 and above.
-* Understand [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/).
-
-
+### kubectl-specific requirements
+* You've installed [kubectl 1.14](https://kubernetes.io/releases/download/) or higher.
+* You've completed the [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) tutorial.
+---
 
 <!-- lessoncontent -->
 
-
-## Real World Example: Configuring Redis using a ConfigMap
-
-Follow the steps below to configure a Redis cache using data stored in a ConfigMap.
-
-First create a ConfigMap with an empty configuration block:
-
+## Step 1: Create a ConfigMap
+1. Run the following commands to create a ConfigMap with an empty configuration block:
 ```shell
 cat <<EOF >./example-redis-config.yaml
 apiVersion: v1
@@ -49,34 +42,27 @@ data:
 EOF
 ```
 
-Apply the ConfigMap created above, along with a Redis pod manifest:
-
+2. Run the following commands to apply the created ConfigMap with a Redis Pod manifest:
 ```shell
 kubectl apply -f example-redis-config.yaml
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
 ```
 
-Examine the contents of the Redis pod manifest and note the following:
+## Step 2: Review your created artifacts
+1. Review the Redis Pod manifest for the following information:
+* Under `volumes`, a new `config` volume is created.
+* On the `config` volume, the `key` and `path` values tell us that the `redis-config` key is shared with the `example-redis-config` ConfigMap as a file named `redis.conf`.
+* The `config` volume is mounted at `/redis-master`.
 
-* A volume named `config` is created by `spec.volumes[1]`
-* The `key` and `path` under `spec.volumes[1].configMap.items[0]` exposes the `redis-config` key from the 
-  `example-redis-config` ConfigMap as a file named `redis.conf` on the `config` volume.
-* The `config` volume is then mounted at `/redis-master` by `spec.containers[0].volumeMounts[1]`.
-
-This has the net effect of exposing the data in `data.redis-config` from the `example-redis-config`
-ConfigMap above as `/redis-master/redis.conf` inside the Pod.
-
+#### Example redis-pod.yaml file
 {{% code_sample file="pods/config/redis-pod.yaml" %}}
 
-Examine the created objects:
-
+2. Run the following command to review the created objects:
 ```shell
 kubectl get pod/redis configmap/example-redis-config 
 ```
-
-You should see the following output:
-
-```
+#### Response
+```shell
 NAME        READY   STATUS    RESTARTS   AGE
 pod/redis   1/1     Running   0          8s
 
@@ -84,14 +70,11 @@ NAME                             DATA   AGE
 configmap/example-redis-config   1      14s
 ```
 
-Recall that we left `redis-config` key in the `example-redis-config` ConfigMap blank:
-
+3. Run the following commaand to confirm that the `redis-config` key is blank in the `example-redis-config` ConfigMap:
 ```shell
 kubectl describe configmap/example-redis-config
 ```
-
-You should see an empty `redis-config` key:
-
+#### Response
 ```shell
 Name:         example-redis-config
 Namespace:    default
@@ -103,56 +86,42 @@ Data
 redis-config:
 ```
 
-Use `kubectl exec` to enter the pod and run the `redis-cli` tool to check the current configuration:
-
+4. Run the following command to enter the Redis Pod and to check the current configuration:
 ```shell
 kubectl exec -it redis -- redis-cli
 ```
 
-Check `maxmemory`:
-
+5. Run the following command to to confirm that your Redis `maxmemory` value is set to the default value of `0`:
 ```shell
 127.0.0.1:6379> CONFIG GET maxmemory
 ```
 
-It should show the default value of 0:
-
-```shell
-1) "maxmemory"
-2) "0"
-```
-
-Similarly, check `maxmemory-policy`:
-
+6. Run the following command to confirm that your Redis `maxmemory-policy` value is set to the default value of `noeviction`:
 ```shell
 127.0.0.1:6379> CONFIG GET maxmemory-policy
 ```
 
-Which should also yield its default value of `noeviction`:
+{{< alert title="Note" color="info" >}}
 
-```shell
-1) "maxmemory-policy"
-2) "noeviction"
-```
+`maxmemory` is a Redis configuration that enables you to set the memory limit at which your eviction policy takes effect. Similarly, `maxmemory-policy` enables you to set the eviction policy when the limit set by `maxmemory` is reached. See [https://redis.io/docs/latest/develop/reference/eviction/] in the Redis documentation to learn more key eviction.
 
-Now let's add some configuration values to the `example-redis-config` ConfigMap:
+{{< /alert >}}
 
+## Step 3: Add configuration values to the ConfigMap
+1. Replace the `example-redis-config` ConfigMap with the following code:
 {{% code_sample file="pods/config/example-redis-config.yaml" %}}
 
-Apply the updated ConfigMap:
-
+2. Run the following command to apply the updated ConfigMap:
 ```shell
 kubectl apply -f example-redis-config.yaml
 ```
 
-Confirm that the ConfigMap was updated:
-
+3. Run the following command to confirm that the ConfigMap is updated:
 ```shell
 kubectl describe configmap/example-redis-config
 ```
 
-You should see the configuration values we just added:
-
+#### Response
 ```shell
 Name:         example-redis-config
 Namespace:    default
@@ -167,86 +136,40 @@ maxmemory 2mb
 maxmemory-policy allkeys-lru
 ```
 
-Check the Redis Pod again using `redis-cli` via `kubectl exec` to see if the configuration was applied:
+{{< alert title="Note" color="info" >}}
 
-```shell
-kubectl exec -it redis -- redis-cli
-```
+While the ConfigMap is updated, the configuration values are not applied to the Redis Pod. You must restart (delete and recreate) the Pod to get the updated ConfigMap values.
 
-Check `maxmemory`:
+{{< /alert >}}
 
-```shell
-127.0.0.1:6379> CONFIG GET maxmemory
-```
-
-It remains at the default value of 0:
-
-```shell
-1) "maxmemory"
-2) "0"
-```
-
-Similarly, `maxmemory-policy` remains at the `noeviction` default setting:
-
-```shell
-127.0.0.1:6379> CONFIG GET maxmemory-policy
-```
-
-Returns:
-
-```shell
-1) "maxmemory-policy"
-2) "noeviction"
-```
-
-The configuration values have not changed because the Pod needs to be restarted to grab updated
-values from associated ConfigMaps. Let's delete and recreate the Pod:
-
+## Step 4: Delete and recreate the Redis Pod
+1. Run the following commands to delete and recreate the Redis Pod
 ```shell
 kubectl delete pod redis
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
 ```
 
-Now re-check the configuration values one last time:
-
+2. Run the following command to enter the Redis Pod and to check the current configuration:
 ```shell
 kubectl exec -it redis -- redis-cli
 ```
 
-Check `maxmemory`:
-
+3. Run the following command to to confirm that your Redis `maxmemory` value is set to the updated value of `2097152`:
 ```shell
 127.0.0.1:6379> CONFIG GET maxmemory
 ```
 
-It should now return the updated value of 2097152:
-
-```shell
-1) "maxmemory"
-2) "2097152"
-```
-
-Similarly, `maxmemory-policy` has also been updated:
-
+4. Run the following command to confirm that your Redis `maxmemory-policy` value is set to the updated value of `allkeys-lru`:
 ```shell
 127.0.0.1:6379> CONFIG GET maxmemory-policy
 ```
 
-It now reflects the desired value of `allkeys-lru`:
-
-```shell
-1) "maxmemory-policy"
-2) "allkeys-lru"
-```
-
-Clean up your work by deleting the created resources:
-
+5. Run the followin command to delete the created resources and clean up:
 ```shell
 kubectl delete pod/redis configmap/example-redis-config
 ```
+---
 
-## {{% heading "whatsnext" %}}
-
-
+## Next steps
 * Learn more about [ConfigMaps](/docs/tasks/configure-pod-container/configure-pod-configmap/).
-* Follow an example of [Updating configuration via a ConfigMap](/docs/tutorials/configuration/updating-configuration-via-a-configmap/).
+* Learn how to [update configuration with a ConfigMap](/docs/tutorials/configuration/updating-configuration-via-a-configmap/).

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -2,19 +2,20 @@
 reviewers:
 - eparis
 - pmorie
-title: Configuring Redis using a ConfigMap
+title: Configure Redis using a ConfigMap
 content_type: tutorial
 weight: 30
 ---
 
 <!-- overview -->
 
-This page provides a real world example of how to configure Redis using a ConfigMap and builds upon the [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) task. 
+In this tutorial, we will walk through a real world example of how to configure Redis using a ConfigMap.
 
+See [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) for more information about ConfigMaps. 
+---
+## {{% heading "What you'll learn" %}}
 
-
-## {{% heading "objectives" %}}
-
+In this tutorial, you’ll learn how to do the following tasks:
 
 * Create a ConfigMap with Redis configuration values
 * Create a Redis Pod that mounts and uses the created ConfigMap


### PR DESCRIPTION
Overview of updates:
- Updated the title to remove the gerund form for being concise and for SEO
- Changed the lead-in statement to make it more welcoming
- Updated how we link to other topics with clear direction on what they will find at that location
- Added horizontal lines between sections of the topic to reflect the Shopify style
- Updated all headings to reflect the Shopify style
- Split the entire list across buckets of steps to make the tutorial feel more piece-meal
- Updated all steps to reflect the Shopify style
- In cases where there is a need to show the response, added appropriate H4 headings
- Added an alert block to highlight important information, along with links to that key information. This can create an opportunity for learning.
- In the section after updating the ConfigMap, removed the redundant steps and simply stated in an alert block that the changes will reflect in the Redis pod only after a restart